### PR TITLE
VADER Sentiment Analysis API (This closes issue #4)

### DIFF
--- a/ml-api/app.py
+++ b/ml-api/app.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 from transformers import pipeline
+from vader_service import VaderService
 
 app = Flask(__name__)
 CORS(app)
@@ -32,6 +33,21 @@ def predict():
         'sentiment': sentiment,
         'emotion': emotion
     })
+
+
+
+vader_service = VaderService()
+
+@app.route('/vader/analyze', methods=['POST'])
+def vader_analyze():
+    data = request.get_json()
+    text = data.get('text', '')
+    if not text:
+        return jsonify({'error': 'No text provided'}), 400
+
+    sentiment = vader_service.analyze(text)
+    return jsonify({'sentiment': sentiment})
+
 
 if __name__ == '__main__':
     app.run(port=5001, debug=True) 

--- a/ml-api/vader_service.py
+++ b/ml-api/vader_service.py
@@ -1,0 +1,17 @@
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+class VaderService:
+    def __init__(self):
+        self.analyzer = SentimentIntensityAnalyzer()
+
+    def analyze(self, text):
+        if not text.strip():
+            return "Neutral"
+        scores = self.analyzer.polarity_scores(text)
+        compound = scores['compound']
+        if compound >= 0.05:
+            return "Positive"
+        elif compound <= -0.05:
+            return "Negative"
+        else:
+            return "Neutral"

--- a/notebook/vader_sentiment_demo.ipynb
+++ b/notebook/vader_sentiment_demo.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f00a6dfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('../ml-api')  # Allow importing from ml-api folder\n",
+    "\n",
+    "from vader_service import VaderService\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b354609d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Text: I love this product!\n",
+      "Predicted Sentiment: Positive\n",
+      "\n",
+      "Text: This is terrible and disappointing.\n",
+      "Predicted Sentiment: Negative\n",
+      "\n",
+      "Text: It’s okay, not the best but not the worst either.\n",
+      "Predicted Sentiment: Positive\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# vader_sentiment_demo.ipynb\n",
+    "\n",
+    "service = VaderService()\n",
+    "\n",
+    "examples = [\n",
+    "    \"I love this product!\",\n",
+    "    \"This is terrible and disappointing.\",\n",
+    "    \"It’s okay, not the best but not the worst either.\"\n",
+    "]\n",
+    "\n",
+    "for text in examples:\n",
+    "    print(f\"Text: {text}\")\n",
+    "    print(\"Predicted Sentiment:\", service.analyze(text))\n",
+    "    print()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds an API endpoint for sentiment analysis using VADER.

- Added `vader_service.py` for logic
- Updated Flask `app.py` to route POST requests
- Added Jupyter notebook demo

This closes #4 issue


https://github.com/user-attachments/assets/432dd43e-e98c-4339-b3c8-00a5887827d0

