### PR TITLE
Added bouncing animations to Analyze News and Track & Compare sections

### DIFF
--- a/client/src/components/FeatureCards.jsx
+++ b/client/src/components/FeatureCards.jsx
@@ -41,9 +41,9 @@ const features = [
       <svg width="40" height="40" viewBox="0 0 40 40" fill="none"><rect x="8" y="10" width="24" height="20" rx="4" fill="#60a5fa" fillOpacity="0.10"/><rect x="13" y="23" width="3" height="7" rx="1.5" fill="#a78bfa"/><rect x="18.5" y="18" width="3" height="12" rx="1.5" fill="#60a5fa"/><rect x="24" y="14" width="3" height="16" rx="1.5" fill="#a78bfa"/></svg>
     ),
     animation: (
-      <svg width="60" height="20" viewBox="0 0 60 20" fill="none" className="mt-2">
-        <polyline points="0,18 15,10 30,15 45,5 60,12" stroke="#a78bfa" strokeWidth="2" fill="none" className="animate-dash" />
-        <circle cx="45" cy="5" r="3" fill="#60a5fa" className="animate-pulse" />
+      <svg width="60" height="20" viewBox="0 0 60 20" fill="none" className="mt-2 ">
+        <polyline points="0,18 15,10 30,15 45,5 60,12" stroke="#a78bfa" strokeWidth="2" fill="none" className="animate-bounce" />
+        <circle cx="45" cy="10" r="3" fill="#60a5fa" className="animate-bounce" />
       </svg>
     )
   }

--- a/client/src/components/FeatureCards.jsx
+++ b/client/src/components/FeatureCards.jsx
@@ -10,9 +10,13 @@ const features = [
     icon: (
       <svg width="40" height="40" viewBox="0 0 40 40" fill="none"><rect x="5" y="8" width="30" height="24" rx="4" fill="#60a5fa" fillOpacity="0.15"/><rect x="9" y="12" width="22" height="4" rx="2" fill="#60a5fa"/><rect x="9" y="18" width="14" height="2.5" rx="1.25" fill="#a78bfa"/><rect x="9" y="22" width="10" height="2.5" rx="1.25" fill="#a78bfa"/></svg>
     ),
+    
     animation: (
-      <div className="w-full h-2 bg-gradient-to-r from-blue-400 to-pink-400 rounded-full animate-pulse mt-2" />
-    )
+  <div className="flex items-center justify-center mt-2">
+    <span className="text-2xl animate-bounce">📰</span> {/* Newspaper emoji */}
+  </div>
+  )
+
   },
   {
     key: "journal",


### PR DESCRIPTION
This pull request enhances the interactivity of feature cards by adding bounce animations:

## Changes:
- Added a bouncing newspaper emoji to the **Analyze News** section on hover, matching the style of the **Log Your Mood** section.
- Enabled bounce animation on the existing emoji for the **Track & Compare** section, which previously lacked animation.
-These updates enhance UI consistency and engagement by bringing uniform hover animations to all three sections: Analyze News, Log Your Mood and Track & Compare which was missing before and ensuring all key feature cards have consistent and lively hover animations.

##BEFORE
<img width="941" height="348" alt="image" src="https://github.com/user-attachments/assets/6c53a5f3-1447-44c2-890e-86cf8fdaacf0" />


##AFTER
<img width="941" height="371" alt="image" src="https://github.com/user-attachments/assets/580c3dab-8f8b-4b34-89aa-45e4e5bd4a29" />
<img width="946" height="368" alt="image" src="https://github.com/user-attachments/assets/cb0466ae-c447-46e3-9b32-79047a8d788a" />
