### PR TITLE
refactor(server): migrate from CommonJS require to ES6 import/export syntax

### DIFF
--- a/server/controllers/analyzeController.js
+++ b/server/controllers/analyzeController.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const pdfParse = require('pdf-parse');
-const mammoth = require('mammoth');
+import fs from 'fs';
+import pdfParse from 'pdf-parse';
+import mammoth from 'mammoth';
 
 async function extractText(file) {
   const ext = file.originalname.split('.').pop().toLowerCase();
@@ -24,7 +24,7 @@ async function extractText(file) {
   throw new Error('Unsupported file type');
 }
 
-const analyzeFile = async (req, res) => {
+export const analyzeFile = async (req, res) => {
   const file = req.file;
   if (!file) return res.status(400).json({ error: 'No file uploaded' });
 
@@ -120,5 +120,3 @@ function analyzeSentiment(text) {
     }
   };
 }
-
-module.exports = { analyzeFile };

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,9 +1,11 @@
-const bcrypt = require('bcryptjs');
-const jwt = require('jsonwebtoken');
-const userModel = require('../models/user');
-require('dotenv').config();
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import userModel from '../models/user.js';
+import dotenv from 'dotenv';
 
-const signup = async (req, res) => {
+dotenv.config();
+
+export const signup = async (req, res) => {
   console.log("Signup request received:", req.body);
 
   try {
@@ -52,7 +54,7 @@ const signup = async (req, res) => {
   }
 };
 
-const signin = async (req, res) => {
+export const signin = async (req, res) => {
   console.log("Signin request received:", req.body);
 
   try {
@@ -86,5 +88,3 @@ const signin = async (req, res) => {
     return res.status(500).json({ message: "internal error" });
   }
 };
-
-module.exports = { signup, signin };

--- a/server/controllers/journalController.js
+++ b/server/controllers/journalController.js
@@ -1,5 +1,5 @@
-const JournalEntry = require('../models/JournalEntry');
-const axios = require('axios');
+import JournalEntry from '../models/JournalEntry.js';
+import axios from 'axios';
 
 /**
  * Creates a new journal entry with sentiment and emotion analysis
@@ -15,7 +15,7 @@ const axios = require('axios');
  * @returns {Object} 500 - Server error if ML service fails or database error
  */
 
-exports.createEntry = async (req, res, next) => {
+export const createEntry = async (req, res, next) => {
   try {
     const { text } = req.body;
     const mlRes = await axios.post('http://localhost:5001/predict', { text });
@@ -37,7 +37,7 @@ exports.createEntry = async (req, res, next) => {
  * @returns {Array} 200 - Array of journal entries sorted by creation date (descending)
  * @returns {Object} 500 - Server error if database query fails
  */
-exports.getEntries = async (req, res, next) => {
+export const getEntries = async (req, res, next) => {
   try {
     const entries = await JournalEntry.find().sort({ createdAt: -1 });
     res.json(entries);
@@ -60,7 +60,7 @@ exports.getEntries = async (req, res, next) => {
  * @returns {Object} 500 - Server error if database query fails
  */
 
-exports.getEntry = async (req, res, next) => {
+export const getEntry = async (req, res, next) => {
   try {
     const entry = await JournalEntry.findById(req.params.id);
     if (!entry) return res.status(404).json({ error: 'Not found' });
@@ -84,7 +84,7 @@ exports.getEntry = async (req, res, next) => {
  * @returns {Object} 500 - Server error if database operation fails
  */
 
-exports.deleteEntry = async (req, res, next) => {
+export const deleteEntry = async (req, res, next) => {
   try {
     const entry = await JournalEntry.findByIdAndDelete(req.params.id);
     if (!entry) return res.status(404).json({ error: 'Not found' });

--- a/server/controllers/newsController.js
+++ b/server/controllers/newsController.js
@@ -1,5 +1,5 @@
-const NewsEntry = require('../models/NewsEntry');
-const axios = require('axios');
+import NewsEntry from '../models/NewsEntry.js';
+import axios from 'axios';
 
 /**
  * Creates a new news entry with sentiment and emotion analysis
@@ -18,7 +18,7 @@ const axios = require('axios');
  * @returns {Object} 500 - Server error if ML service fails or database error
  */
 
-exports.createEntry = async (req, res, next) => {
+export const createEntry = async (req, res, next) => {
   try {
     // Extract news article data from request body
     const { url, title, text, date } = req.body;
@@ -52,7 +52,7 @@ exports.createEntry = async (req, res, next) => {
  * @returns {Object} 500 - Server error if database query fails
  */
 
-exports.getEntries = async (req, res, next) => {
+export const getEntries = async (req, res, next) => {
   try {
     // Fetch all news entries from database, sorted by date (newest first)
     // This returns entries with all fields: url, title, sentiment, emotion, date
@@ -78,7 +78,7 @@ exports.getEntries = async (req, res, next) => {
  * @returns {Object} 500 - Server error if database query fails
  */
 
-exports.getEntry = async (req, res, next) => {
+export const getEntry = async (req, res, next) => {
   try {
     // Fetch all news entries from database, sorted by date (newest first)
     // This returns entries with all fields: url, title, sentiment, emotion, date
@@ -107,7 +107,7 @@ exports.getEntry = async (req, res, next) => {
  * @returns {Object} 500 - Server error if database operation fails
  */
 
-exports.deleteEntry = async (req, res, next) => {
+export const deleteEntry = async (req, res, next) => {
   try {
     // Find and delete news entry by MongoDB ObjectId in one operation
     const entry = await NewsEntry.findByIdAndDelete(req.params.id);

--- a/server/index.js
+++ b/server/index.js
@@ -1,13 +1,13 @@
-const express = require('express');
-const mongoose = require('mongoose');
-const cors = require('cors');
-const dotenv = require('dotenv');
-const errorHandler = require('./middleware/errorHandler');
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import errorHandler from './middleware/errorHandler.js';
 
-const journalRoutes = require('./routes/journal');
-const newsRoutes = require('./routes/news');
-const authRouter = require('./routes/authRoute');
-const analyzeRoutes = require('./routes/analyze');
+import journalRoutes from './routes/journal.js';
+import newsRoutes from './routes/news.js';
+import authRouter from './routes/authRoute.js';
+import analyzeRoutes from './routes/analyze.js';
 
 dotenv.config();
 const app = express();

--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -3,4 +3,4 @@ function errorHandler(err, req, res, next) {
   res.status(500).json({ error: err.message || 'Internal Server Error' });
 }
 
-module.exports = errorHandler; 
+export default errorHandler; 

--- a/server/middleware/jwt.js
+++ b/server/middleware/jwt.js
@@ -1,15 +1,14 @@
-const express=require('express')
-const jwt=require('jsonwebtoken')
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
 
-
-require('dotenv').config()
-const Jwt_USER_SECRET=process.env.Jwt_USER_SECRET
+dotenv.config();
+const Jwt_USER_SECRET = process.env.Jwt_USER_SECRET;
 
 async function jwtmiddleware(req,res,next){
     try{
         const token=req.headers.token
         if(!token){
-           return res.status(401).json({
+            return res.status(401).json({
                 message:"token not found"
             })
         }
@@ -22,4 +21,5 @@ async function jwtmiddleware(req,res,next){
         })
     }
 }
-module.exports=jwtmiddleware;
+
+export default jwtmiddleware;

--- a/server/models/AnalyzeResult.js
+++ b/server/models/AnalyzeResult.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
 const analyzeResultSchema = new mongoose.Schema({
   fileName: String,
@@ -11,4 +11,4 @@ const analyzeResultSchema = new mongoose.Schema({
   },
 });
 
-module.exports = mongoose.model('AnalyzeResult', analyzeResultSchema);
+export default mongoose.model('AnalyzeResult', analyzeResultSchema);

--- a/server/models/JournalEntry.js
+++ b/server/models/JournalEntry.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
 const JournalEntrySchema = new mongoose.Schema({
   text: { type: String, required: true },
@@ -7,4 +7,4 @@ const JournalEntrySchema = new mongoose.Schema({
   createdAt: { type: Date, default: Date.now }
 });
 
-module.exports = mongoose.model('JournalEntry', JournalEntrySchema); 
+export default mongoose.model('JournalEntry', JournalEntrySchema); 

--- a/server/models/NewsEntry.js
+++ b/server/models/NewsEntry.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
 const NewsEntrySchema = new mongoose.Schema({
   url: String,
@@ -8,4 +8,4 @@ const NewsEntrySchema = new mongoose.Schema({
   date: Date
 });
 
-module.exports = mongoose.model('NewsEntry', NewsEntrySchema); 
+export default mongoose.model('NewsEntry', NewsEntrySchema); 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,14 +1,14 @@
-const mongoose=require('mongoose')
+import mongoose from 'mongoose';
 
-const Schema=mongoose.Schema
+const Schema = mongoose.Schema;
 
-const user=new Schema({
+const user = new Schema({
     firstname: String,
     lastname: String,
-    email:{type:String, unique:true},
-    password:String,
-})
+    email: { type: String, unique: true },
+    password: String,
+});
 
-const userModel=mongoose.model("user",user);
+const userModel = mongoose.model("user", user);
 
-module.exports=userModel;
+export default userModel;

--- a/server/package.json
+++ b/server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",

--- a/server/routes/analyze.js
+++ b/server/routes/analyze.js
@@ -1,10 +1,10 @@
-const express = require('express');
-const multer = require('multer');
-const { analyzeFile } = require('../controllers/analyzeController');
+import express from 'express';
+import multer from 'multer';
+import { analyzeFile } from '../controllers/analyzeController.js';
 
 const router = express.Router();
 const upload = multer({ dest: 'uploads/' });
 
 router.post('/', upload.single('file'), analyzeFile);
 
-module.exports = router;
+export default router;

--- a/server/routes/authRoute.js
+++ b/server/routes/authRoute.js
@@ -1,9 +1,9 @@
-const { Router } = require('express');
-const { signup, signin } = require('../controllers/authController'); // your logic here
+import { Router } from 'express';
+import { signup, signin } from '../controllers/authController.js';
 
 const authRouter = Router();
 
 authRouter.post('/signup', signup);
 authRouter.post('/signin', signin);
 
-module.exports = authRouter;
+export default authRouter;

--- a/server/routes/journal.js
+++ b/server/routes/journal.js
@@ -1,14 +1,15 @@
-const express = require('express');
+import express from 'express';
+import { createEntry, getEntries, getEntry, deleteEntry } from '../controllers/journalController.js';
+
 const router = express.Router();
-const journalController = require('../controllers/journalController');
 
 // Create and analyze
-router.post('/', journalController.createEntry);
+router.post('/', createEntry);
 // Get all
-router.get('/', journalController.getEntries);
+router.get('/', getEntries);
 // Get one
-router.get('/:id', journalController.getEntry);
+router.get('/:id', getEntry);
 // Delete
-router.delete('/:id', journalController.deleteEntry);
+router.delete('/:id', deleteEntry);
 
-module.exports = router; 
+export default router; 

--- a/server/routes/news.js
+++ b/server/routes/news.js
@@ -1,14 +1,15 @@
-const express = require('express');
+import express from 'express';
+import { createEntry, getEntries, getEntry, deleteEntry } from '../controllers/newsController.js';
+
 const router = express.Router();
-const newsController = require('../controllers/newsController');
 
 // Create and analyze
-router.post('/', newsController.createEntry);
+router.post('/', createEntry);
 // Get all
-router.get('/', newsController.getEntries);
+router.get('/', getEntries);
 // Get one
-router.get('/:id', newsController.getEntry);
+router.get('/:id', getEntry);
 // Delete
-router.delete('/:id', newsController.deleteEntry);
+router.delete('/:id', deleteEntry);
 
-module.exports = router; 
+export default router; 

--- a/server/tempCodeRunnerFile.js
+++ b/server/tempCodeRunnerFile.js
@@ -1,12 +1,14 @@
-const express = require('express');
-const cors = require('cors');
-const mongoose = require('mongoose');
-require('dotenv').config();
+import express from 'express';
+import cors from 'cors';
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
 
-const journalRoutes = require('./routes/journal');
-const newsRoutes = require('./routes/news');
-const errorHandler = require('./middleware/errorHandler');
-const { authRouter } = require('./routes/authRoute');
+import journalRoutes from './routes/journal.js';
+import newsRoutes from './routes/news.js';
+import errorHandler from './middleware/errorHandler.js';
+import authRouter from './routes/authRoute.js';
+
+dotenv.config();
 
 const app = express();
 app.use(cors());
@@ -19,7 +21,6 @@ mongoose.connect(process.env.MONGO_URI)
 app.use('/api/journal', journalRoutes);
 app.use('/api/news', newsRoutes);
 app.use(errorHandler);
-
 
 app.use("/auth", authRouter);
 

--- a/server/utils/jwt.js
+++ b/server/utils/jwt.js
@@ -1,4 +1,4 @@
-const jwt = require('jsonwebtoken');
+import jwt from 'jsonwebtoken';
 const JWT_SECRET = process.env.Jwt_USER_SECRET;
 
 const createToken = (payload) => jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
@@ -11,4 +11,4 @@ const verifyToken = (token) => {
   }
 };
 
-module.exports = { createToken, verifyToken };
+export { createToken, verifyToken };


### PR DESCRIPTION
### Changes Introduced
- Replaced all `require()` statements with ES6 `import` syntax.
- Updated all `module.exports` to use `export`/`export default`.
- Ensured compatibility with existing project structure and tooling.

### Motivation
- Aligns codebase with modern JavaScript standards.
- Improves readability and maintainability.
- Prepares backend for future migration to ESM-based frameworks.


Fixes #23 

Kindly assign the GSSoC'25 label to this PR.