### PR TITLE
fix: guard sensitive console logs in signup and login pages

### DIFF
--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -11,7 +11,10 @@ function LoginPage() {
     e.preventDefault();
     setError("");
 
-    console.log("VITE_API_URL is:", import.meta.env.VITE_API_URL);
+    // Removed: Logging API URL in production is not safe
+    if (import.meta.env.MODE !== "production") {
+      console.log("VITE_API_URL is:", import.meta.env.VITE_API_URL);
+    }
 
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/signin`, {
@@ -27,8 +30,11 @@ function LoginPage() {
         console.warn("Response body not JSON or empty.");
       }
 
-      console.log("Received response status:", res.status);
-      console.log("Received response data:", data);
+      // Only log response status/data in non-production
+      if (import.meta.env.MODE !== "production") {
+        console.log("Received response status:", res.status);
+        console.log("Received response data:", data);
+      }
 
       if (res.ok && data.token) {
         localStorage.setItem("token", data.token);

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -30,6 +30,9 @@ export default function ResetPassword() {
       setTimeout(() => navigate('/login'), 2000);
     } catch (err) {
       setError(err.response?.data?.message || 'Something went wrong');
+      if (import.meta.env.MODE !== "production") {
+        console.error("Network error during password reset:", err);
+      }
     }
   };
 

--- a/client/src/pages/SignupPage.jsx
+++ b/client/src/pages/SignupPage.jsx
@@ -23,7 +23,10 @@ function SignupPage() {
     setError("");
     setSuccess("");
 
-    console.log("VITE_API_URL is:", import.meta.env.VITE_API_URL);
+    // Removed: Logging API URL in production is not safe
+    if (import.meta.env.MODE !== "production") {
+      console.log("VITE_API_URL is:", import.meta.env.VITE_API_URL);
+    }
 
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/signup`, {
@@ -39,8 +42,11 @@ function SignupPage() {
         console.warn("Response body not JSON or empty.");
       }
 
-      console.log("Received response status:", res.status);
-      console.log("Received response data:", data);
+      // Only log response status/data in non-production
+      if (import.meta.env.MODE !== "production") {
+        console.log("Received response status:", res.status);
+        console.log("Received response data:", data);
+      }
 
       if (res.ok && data.token) {
         localStorage.setItem("token", data.token);


### PR DESCRIPTION
Sensitive console logs in the Signup page (such as API URLs and server responses) are now only shown in non-production environments. This helps prevent accidental exposure of sensitive information in production logs, while still allowing useful debugging in development.